### PR TITLE
fix: Relax the httpx version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ keywords = [
 ]
 dependencies = [
     "griffe>=1.7.2",
-    "httpx>=0.28.1",
+    "httpx>=0.27.2",
     "pydantic>=2.11.3",
     "tenacity>=9.1.2",
     "typing-extensions>=4.13.2",

--- a/uv.lock
+++ b/uv.lock
@@ -27,7 +27,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "griffe", specifier = ">=1.7.2" },
-    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx", specifier = ">=0.27.2" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "tenacity", specifier = ">=9.1.2" },
     { name = "typing-extensions", specifier = ">=4.13.2" },


### PR DESCRIPTION
Requiring `httpx>=0.28.1` would make our library incompatible with CrewAI:

```shell
❯ uv add aci-sdk

  × No solution found when resolving dependencies for split (python_full_version >= '3.13'):
  ╰─▶ Because your project depends on aci-sdk and all versions of aci-sdk depend on httpx>=0.28.1, we can conclude that your project depends on httpx>=0.28.1.
      And because litellm==1.60.2 depends on httpx>=0.23.0,<0.28.0 and crewai>=0.108.0 depends on litellm==1.60.2, we can conclude that your project and
      crewai>=0.108.0 are incompatible.
      And because only the following versions of crewai are available:
          crewai<=0.108.0
          crewai==0.114.0
      and aipolabs-agents:dev depends on crewai>=0.108.0, we can conclude that your project and aipolabs-agents:dev are incompatible.
      And because your project requires your project and aipolabs-agents:dev, we can conclude that your project's requirements are unsatisfiable.
  help: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the minimum required version of the `httpx` dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->