### PR TITLE
feat: Add py.typed to enable mypy type hints for users

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,8 @@
 name = "aci-sdk"
 version = "0.0.2b2"
 description = "Add your description here"
-authors = [
-    { name="Aipolabs", email="support@aipolabs.xyz" }
-]
-maintainers = [
-    { name="Aipolabs", email="support@aipolabs.xyz" }
-]
+authors = [{ name = "Aipolabs", email = "support@aipolabs.xyz" }]
+maintainers = [{ name = "Aipolabs", email = "support@aipolabs.xyz" }]
 readme = "README.md"
 requires-python = ">=3.10"
 homepage = "https://aci.dev"
@@ -63,7 +59,6 @@ select = [
 extend-ignore = ["E501"]
 
 
-
 [tool.ruff.lint.pycodestyle]
 ignore-overlong-task-comments = true
 
@@ -94,8 +89,9 @@ dev = [
 ]
 
 [build-system]
-requires = [ "hatchling",]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["aci"]
+force-include = [{ "aci/py.typed" = "aci/py.typed" }]


### PR DESCRIPTION
`py.typedz Marker: An empty file named exactly `py.typed` placed in the root directory of your installed package. This file signals to Mypy that the library itself contains inline type annotations (e.g., def my_func(x: int) -> str: ...) and that Mypy should trust and analyze them.

Without it, users of our library will see the following error:
<img width="865" alt="Screenshot 2025-04-19 at 5 42 41 PM" src="https://github.com/user-attachments/assets/d25680d5-5197-4b20-afc5-241604a36932" />

```shell
examples/llamaindex/llamaindex_with_pre_planned_tool.py:5: error: Skipping analyzing "aci": module is installed, but missing library stubs or py.typed marker  [import-untyped]
examples/llamaindex/llamaindex_with_pre_planned_tool.py:6: error: Skipping analyzing "aci.types.functions": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved formatting and consistency in project configuration fields.
  - Removed unnecessary blank lines and trailing commas in configuration sections.
  - Explicitly included the `aci/py.typed` file in the package build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->