### PR TITLE
feat/change-field-name-for-allowed_only-in-function-search-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ from aci.types.enums import FunctionDefinitionFormat
 functions: list[dict] = client.functions.search(
     app_names=["BRAVE_SEARCH", "TAVILY"],
     intent="I want to search the web",
-    allowed_apps_only=False, # If true, only returns functions of apps that are allowed by the agent/accessor, identified by the api key.
+    allowed_only=False, # If true, only returns enabled functions of apps that are allowed by the agent/accessor, identified by the api key.
     format=FunctionDefinitionFormat.OPENAI, # The format of the functions, can be OPENAI, ANTHROPIC, BASIC (name and description only)
     limit=10,
     offset=0
@@ -317,7 +317,7 @@ result = client.handle_function_call(
     tool_call.function.name,
     json.loads(tool_call.function.arguments),
     linked_account_owner_id="john_doe",
-    allowed_apps_only=True,
+    allowed_only=True,
     format=FunctionDefinitionFormat.OPENAI
 )
 ```

--- a/aci/_client.py
+++ b/aci/_client.py
@@ -89,7 +89,7 @@ class ACI:
         function_name: str,
         function_arguments: dict,
         linked_account_owner_id: str,
-        allowed_apps_only: bool = False,
+        allowed_only: bool = False,
         format: FunctionDefinitionFormat = FunctionDefinitionFormat.OPENAI,
     ) -> Any:
         """Routes and executes function calls based on the function name.
@@ -103,7 +103,7 @@ class ACI:
             function_arguments: Dictionary containing the input arguments for the function.
             linked_account_owner_id: To specify the end-user (account owner) on behalf of whom you want to execute functions
             You need to first link corresponding account with the same owner id in the ACI dashboard (https://platform.aci.dev).
-            allowed_apps_only: If true, only returns functions/apps that are allowed to be used by the agent/accessor, identified by the api key.
+            allowed_only: If true, only returns enabled functions from the apps that are allowed to be used by the agent/accessor, identified by the api key.
             format: Decides the function definition format returned by ACI_SEARCH_FUNCTIONS (which fundamnetally is 'functions.search')
         Returns:
             Any: The result (serializable) of the function execution. It varies based on the function.
@@ -113,13 +113,13 @@ class ACI:
             f"name={function_name}, "
             f"params={function_arguments}, "
             f"linked_account_owner_id={linked_account_owner_id}, "
-            f"allowed_apps_only={allowed_apps_only}, "
+            f"allowed_only={allowed_only}, "
             f"format={format}"
         )
         if function_name == ACISearchFunctions.get_name():
             functions = self.functions.search(
                 **function_arguments,
-                allowed_apps_only=allowed_apps_only,
+                allowed_only=allowed_only,
                 format=format,
             )
 

--- a/aci/meta_functions/_aci_search_functions.py
+++ b/aci/meta_functions/_aci_search_functions.py
@@ -5,7 +5,7 @@ relevant executable functions that can help complete tasks.
 The ACI_SEARCH_FUNCTIONS is basically the json schema version of the SDK's client.functions.search(...) method,
 but simplified with less parameters to make it more reliable for LLM function calling:
 - It focuses primarily on the 'intent' parameter to find relevant functions
-- It omits 'app_names', 'allowed_apps_only', 'format' parameters to simplify the interface
+- It omits 'app_names', 'allowed_only', 'format' parameters to simplify the interface
 - It keeps pagination functionality with 'limit' and 'offset' parameters
 
 Use this meta function when you want an LLM to discover relevant executable functions based on

--- a/aci/resource/functions.py
+++ b/aci/resource/functions.py
@@ -24,7 +24,7 @@ class FunctionsResource(APIResource):
         self,
         app_names: list[str] | None = None,
         intent: str | None = None,
-        allowed_apps_only: bool = False,
+        allowed_only: bool = False,
         format: FunctionDefinitionFormat = FunctionDefinitionFormat.OPENAI,
         limit: int | None = None,
         offset: int | None = None,
@@ -35,7 +35,7 @@ class FunctionsResource(APIResource):
         Args:
             app_names: List of app names to filter functions by.
             intent: search results will be sorted by relevance to this intent.
-            allowed_apps_only: If true, only returns functions of apps that are allowed by the
+            allowed_only: If true, only returns enabled functions of apps that are allowed by the
                 agent/accessor, identified by the api key.
             limit: for pagination, maximum number of functions to return.
             offset: for pagination, number of functions to skip before returning results.
@@ -49,7 +49,7 @@ class FunctionsResource(APIResource):
         validated_params = SearchFunctionsParams(
             app_names=app_names,
             intent=intent,
-            allowed_apps_only=allowed_apps_only,
+            allowed_only=allowed_only,
             format=format,
             limit=limit,
             offset=offset,

--- a/aci/types/functions.py
+++ b/aci/types/functions.py
@@ -50,7 +50,7 @@ class SearchFunctionsParams(BaseModel):
 
     app_names: list[str] | None = None
     intent: str | None = None
-    allowed_apps_only: bool = False
+    allowed_only: bool = False
     format: FunctionDefinitionFormat = FunctionDefinitionFormat.OPENAI
     limit: int | None = None
     offset: int | None = None

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -30,7 +30,7 @@ MOCK_FUNCTION_ARGUMENTS = {"param1": "value1", "param2": "value2"}
         {
             "app_names": ["TEST"],
             "intent": "test",
-            "allowed_apps_only": True,
+            "allowed_only": True,
             "format": FunctionDefinitionFormat.OPENAI,
             "limit": 10,
             "offset": 0,


### PR DESCRIPTION
changed the field name from `allowed_apps_only` to `allowed_only` for function search API for the function level enablement settings

Ticket:
https://www.notion.so/Update-TS-Python-SDK-to-use-allowed_only-field-2498378d6a4780019d40e8de433a39d7?v=c135b6e7f76243819caf99a83e291380&source=copy_link
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Renamed the function search API field from `allowed_apps_only` to `allowed_only` for clarity and consistency across code, docs, and tests.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed public parameter allowed_apps_only to allowed_only across function search and unified function call handler. Behavior and defaults unchanged; update integrations to use the new name.

- Documentation
  - Updated README examples and comments to reflect the new parameter name and clarify that it returns enabled/allowed functions.

- Tests
  - Updated unit tests to use allowed_only in search parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->