### PR TITLE
feat/replace-allowed_apps_only-by-allowed_only-in-function-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ from aci.types.enums import FunctionDefinitionFormat
 functions: list[dict] = client.functions.search(
     app_names=["BRAVE_SEARCH", "TAVILY"],
     intent="I want to search the web",
-    allowed_apps_only=False, # If true, only returns functions of apps that are allowed by the agent/accessor, identified by the api key.
+    allowed_only=False, # If true, only returns functions of apps that are allowed by the agent/accessor, identified by the api key.
     format=FunctionDefinitionFormat.OPENAI, # The format of the functions, can be OPENAI, ANTHROPIC, BASIC (name and description only)
     limit=10,
     offset=0
@@ -317,7 +317,7 @@ result = client.handle_function_call(
     tool_call.function.name,
     json.loads(tool_call.function.arguments),
     linked_account_owner_id="john_doe",
-    allowed_apps_only=True,
+    allowed_only=True,
     format=FunctionDefinitionFormat.OPENAI
 )
 ```

--- a/aci/_client.py
+++ b/aci/_client.py
@@ -90,6 +90,7 @@ class ACI:
         function_arguments: dict,
         linked_account_owner_id: str,
         allowed_apps_only: bool = False,
+        allowed_only: bool = False,
         format: FunctionDefinitionFormat = FunctionDefinitionFormat.OPENAI,
     ) -> Any:
         """Routes and executes function calls based on the function name.
@@ -103,7 +104,8 @@ class ACI:
             function_arguments: Dictionary containing the input arguments for the function.
             linked_account_owner_id: To specify the end-user (account owner) on behalf of whom you want to execute functions
             You need to first link corresponding account with the same owner id in the ACI dashboard (https://platform.aci.dev).
-            allowed_apps_only: If true, only returns functions/apps that are allowed to be used by the agent/accessor, identified by the api key.
+            allowed_apps_only: Deprecated, use `allowed_only` instead. If true, only returns enabled functions of apps that are allowed to be used by the agent/accessor, identified by the api key.
+            allowed_only: If true, only returns enabled functions of apps that are allowed to be used by the agent/accessor, identified by the api key.
             format: Decides the function definition format returned by ACI_SEARCH_FUNCTIONS (which fundamnetally is 'functions.search')
         Returns:
             Any: The result (serializable) of the function execution. It varies based on the function.
@@ -114,12 +116,13 @@ class ACI:
             f"params={function_arguments}, "
             f"linked_account_owner_id={linked_account_owner_id}, "
             f"allowed_apps_only={allowed_apps_only}, "
+            f"allowed_only={allowed_only}, "
             f"format={format}"
         )
         if function_name == ACISearchFunctions.get_name():
             functions = self.functions.search(
                 **function_arguments,
-                allowed_apps_only=allowed_apps_only,
+                allowed_only=allowed_only or allowed_apps_only,
                 format=format,
             )
 

--- a/aci/meta_functions/_aci_search_functions.py
+++ b/aci/meta_functions/_aci_search_functions.py
@@ -5,7 +5,7 @@ relevant executable functions that can help complete tasks.
 The ACI_SEARCH_FUNCTIONS is basically the json schema version of the SDK's client.functions.search(...) method,
 but simplified with less parameters to make it more reliable for LLM function calling:
 - It focuses primarily on the 'intent' parameter to find relevant functions
-- It omits 'app_names', 'allowed_apps_only', 'format' parameters to simplify the interface
+- It omits 'app_names', 'allowed_only', 'format' parameters to simplify the interface
 - It keeps pagination functionality with 'limit' and 'offset' parameters
 
 Use this meta function when you want an LLM to discover relevant executable functions based on

--- a/aci/resource/functions.py
+++ b/aci/resource/functions.py
@@ -49,6 +49,13 @@ class FunctionsResource(APIResource):
         Raises:
             Various exceptions defined in _handle_response for different HTTP status codes.
         """
+
+        # TODO: remove this after allowed_apps_only is removed
+        if allowed_apps_only and not allowed_only:
+            logger.warning(
+                "'allowed_apps_only' is deprecated and will be removed in a future version; use 'allowed_only' instead."
+            )
+
         validated_params = SearchFunctionsParams(
             app_names=app_names,
             intent=intent,

--- a/aci/resource/functions.py
+++ b/aci/resource/functions.py
@@ -25,6 +25,7 @@ class FunctionsResource(APIResource):
         app_names: list[str] | None = None,
         intent: str | None = None,
         allowed_apps_only: bool = False,
+        allowed_only: bool = False,
         format: FunctionDefinitionFormat = FunctionDefinitionFormat.OPENAI,
         limit: int | None = None,
         offset: int | None = None,
@@ -35,7 +36,9 @@ class FunctionsResource(APIResource):
         Args:
             app_names: List of app names to filter functions by.
             intent: search results will be sorted by relevance to this intent.
-            allowed_apps_only: If true, only returns functions of apps that are allowed by the
+            allowed_apps_only: Deprecated, use `allowed_only` instead. If true, only returns enabled functions of apps that are allowed by the
+                agent/accessor, identified by the api key.
+            allowed_only: If true, only returns enabled functions of apps that are allowed by the
                 agent/accessor, identified by the api key.
             limit: for pagination, maximum number of functions to return.
             offset: for pagination, number of functions to skip before returning results.
@@ -49,7 +52,7 @@ class FunctionsResource(APIResource):
         validated_params = SearchFunctionsParams(
             app_names=app_names,
             intent=intent,
-            allowed_apps_only=allowed_apps_only,
+            allowed_only=allowed_only or allowed_apps_only,
             format=format,
             limit=limit,
             offset=offset,

--- a/aci/types/functions.py
+++ b/aci/types/functions.py
@@ -1,4 +1,4 @@
-from typing import Any, Annotated
+from typing import Annotated, Any
 
 from pydantic import BaseModel
 

--- a/aci/types/functions.py
+++ b/aci/types/functions.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Annotated
 
 from pydantic import BaseModel
 
@@ -50,7 +50,8 @@ class SearchFunctionsParams(BaseModel):
 
     app_names: list[str] | None = None
     intent: str | None = None
-    allowed_apps_only: bool = False
+    allowed_apps_only: Annotated[bool, "deprecated"] = False
+    allowed_only: bool = False
     format: FunctionDefinitionFormat = FunctionDefinitionFormat.OPENAI
     limit: int | None = None
     offset: int | None = None

--- a/aci/types/functions.py
+++ b/aci/types/functions.py
@@ -1,6 +1,6 @@
-from typing import Annotated, Any
+from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from aci.types.enums import FunctionDefinitionFormat
 
@@ -50,7 +50,11 @@ class SearchFunctionsParams(BaseModel):
 
     app_names: list[str] | None = None
     intent: str | None = None
-    allowed_apps_only: Annotated[bool, "deprecated"] = False
+    allowed_apps_only: bool = Field(
+        default=False,
+        description="Deprecated, use `allowed_only` instead. If true, only returns enabled functions of apps that are allowed by the agent/accessor, identified by the api key.",
+        deprecated=True,
+    )
     allowed_only: bool = False
     format: FunctionDefinitionFormat = FunctionDefinitionFormat.OPENAI
     limit: int | None = None


### PR DESCRIPTION
Deprecate "allowed_apps_only" and replace it by "allowed_only" for functions search method
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced the deprecated "allowed_apps_only" parameter with "allowed_only" in the functions search method to simplify usage and improve clarity.

- **Migration**
 - Updated all references and documentation to use "allowed_only".
 - "allowed_apps_only" is still accepted for backward compatibility but marked as deprecated.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an allowed_only option to filter returned/handled functions/apps while remaining backward-compatible.

* **Deprecations**
  * allowed_apps_only deprecated in favor of allowed_only; existing integrations continue to work and will be honored.

* **Documentation**
  * README examples updated to use allowed_only.

* **Chores**
  * Logging and parameter handling improved to support both flags and emit deprecation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->