### PR TITLE
chore: bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aci-sdk"
-version = "1.0.0b3"
+version = "1.0.0b4"
 description = "The Python SDK for the Agent Computer Interface (ACI) by Aipotheosis Labs"
 authors = [{ name = "Aipolabs", email = "support@aipolabs.xyz" }]
 maintainers = [{ name = "Aipolabs", email = "support@aipolabs.xyz" }]


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bumped aci-sdk version to 1.0.0b4 to prepare the next beta release. No code or behavior changes.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented application version from 1.0.0b3 to 1.0.0b4 for the next beta rollout. No functional changes or dependency updates. You may notice the new version in About dialogs, package metadata, and release notes. No action required unless you gate workflows on version numbers; upgrade is safe and does not affect features or compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->